### PR TITLE
fix: fix attw cli version to v0.15

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,14 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
 
     - name: Check if the Types Are Wrong
       shell: bash
-      run: npx -p @arethetypeswrong/cli attw --pack ${{ inputs.working-directory }} ${{ inputs.block-esm != 'true' && '--ignore-rules cjs-resolves-to-esm' || '' }}
+      run: |
+        # Change directory to inputs.working-directory if it is set
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          cd ${{ inputs.working-directory }}
+        fi
+
+        npx -p @arethetypeswrong/cli@0.16 attw --pack ${{ inputs.block-esm != 'true' && '--ignore-rules cjs-resolves-to-esm' || '' }}

--- a/action.yml
+++ b/action.yml
@@ -28,10 +28,4 @@ runs:
 
     - name: Check if the Types Are Wrong
       shell: bash
-      run: |
-        # Change directory to inputs.working-directory if it is set
-        if [ -n "${{ inputs.working-directory }}" ]; then
-          cd ${{ inputs.working-directory }}
-        fi
-
-        npx -p @arethetypeswrong/cli@0.16 attw --pack ${{ inputs.block-esm != 'true' && '--ignore-rules cjs-resolves-to-esm' || '' }}
+      run: npx -p @arethetypeswrong/cli@0.15 attw --pack ${{ inputs.working-directory }} ${{ inputs.block-esm != 'true' && '--ignore-rules cjs-resolves-to-esm' || '' }}


### PR DESCRIPTION
As noted in the below issue, using npm with a directory is broken in @arethetypeswrong/cli@0.16.0. Instead, we cd into the directory before running npm pack. https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/179